### PR TITLE
Fix the binding BUG of "Convert Segment" submenu in Sketch

### DIFF
--- a/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchEditorTool.cs
+++ b/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchEditorTool.cs
@@ -398,10 +398,10 @@ namespace Macad.Interaction.Editors.Shapes
             itemList.AddCommand(SketchCommands.SplitElement);
 
             itemList.AddGroup("Convert Segment");
-            __AddIfExecutable(SketchCommands.ConvertSegment, SketchCommands.Segments.Line);
-            __AddIfExecutable(SketchCommands.ConvertSegment, SketchCommands.Segments.Bezier);
-            __AddIfExecutable(SketchCommands.ConvertSegment, SketchCommands.Segments.Arc);
-            __AddIfExecutable(SketchCommands.ConvertSegment, SketchCommands.Segments.EllipticalArc);
+            itemList.AddCommand(SketchCommands.ConvertSegment, SketchCommands.Segments.Line);
+            itemList.AddCommand(SketchCommands.ConvertSegment, SketchCommands.Segments.Bezier);
+            itemList.AddCommand(SketchCommands.ConvertSegment, SketchCommands.Segments.Arc);
+            itemList.AddCommand(SketchCommands.ConvertSegment, SketchCommands.Segments.EllipticalArc);
             itemList.CloseGroup();
 
             itemList.AddCommand(SketchCommands.RecenterGrid);


### PR DESCRIPTION
Fix the binding BUG of "Convert Segment" submenu in Sketch right-click menu. 