### PR TITLE
Fix several follow-up typos

### DIFF
--- a/Build/MSBuild/Macad.Icons.targets
+++ b/Build/MSBuild/Macad.Icons.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Icon Conversion from SVG to XAML and Merge into a single Ressource Dictionary -->
+  <!-- Icon Conversion from SVG to XAML and Merge into a single Resource Dictionary -->
 
   <Import Project="Macad.Common.props" Condition="!Exists('$(MMRootDir)')" />
   

--- a/Build/Setup/_Dependencies.iss
+++ b/Build/Setup/_Dependencies.iss
@@ -25,7 +25,7 @@ begin
         if RegQueryDWordValue(HKEY_LOCAL_MACHINE, key, 'RBld', rbld) then 
         begin
             Log('VC Redist Major is: ' + IntToStr(major) + ' Minor is: ' + IntToStr(minor) + ' Bld is: ' + IntToStr(bld) + ' Rbld is: ' + IntToStr(rbld));
-            // Note brackets required because of weird operator precendence
+            // Note brackets required because of weird operator precedence
             Result := (major >= {#VcRedistMajor}) and (minor >= {#VcRedistMinor}) and ({#VcRedistBuild} >= 24212)
         end;
       end;

--- a/Build/_Common.csx
+++ b/Build/_Common.csx
@@ -39,7 +39,7 @@ public static class Common
         }
         catch(Exception e)
         {
-            Printer.Error($"The following process could not be startet: {path}");
+            Printer.Error($"The following process could not be started: {path}");
             Printer.Error($"Message: {e.Message}");
             return -1;
         }

--- a/Source/Macad.Interaction/Commands/SketchCommands.cs
+++ b/Source/Macad.Interaction/Commands/SketchCommands.cs
@@ -192,7 +192,7 @@ public static class SketchCommands
                 return;
             }
 
-            using (new ProcessingScope(tool.Sketch, "Import sketch from cliboard."))
+            using (new ProcessingScope(tool.Sketch, "Import sketch from clipboard."))
             {
                 if (replace && points?.Count > 0)
                 {

--- a/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchSegmentArcCenterCreator.cs
+++ b/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchSegmentArcCenterCreator.cs
@@ -49,7 +49,7 @@ public sealed class SketchSegmentArcCenterCreator : SketchSegmentCreator
 
     public override bool Continue(int continueWithPoint)
     {
-        // Start the next line with the first point already catched
+        // Start the next line with the first point already caught
         _Points[0] = SketchEditorTool.Sketch.Points[continueWithPoint];
         _MergePointIndices[0] = continueWithPoint;
 

--- a/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchSegmentArcRimCreator.cs
+++ b/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchSegmentArcRimCreator.cs
@@ -51,7 +51,7 @@ public sealed class SketchSegmentArcRimCreator : SketchSegmentCreator
 
     public override bool Continue(int continueWithPoint)
     {
-        // Start the next line with the first point already catched
+        // Start the next line with the first point already caught
         _Points[0] = SketchEditorTool.Sketch.Points[continueWithPoint];
         _MergePointIndices[0] = continueWithPoint;
 

--- a/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchSegmentBezier2Creator.cs
+++ b/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchSegmentBezier2Creator.cs
@@ -51,7 +51,7 @@ public sealed class SketchSegmentBezier2Creator : SketchSegmentCreator
 
     public override bool Continue(int continueWithPoint)
     {
-        // Start the next line with the first point already catched
+        // Start the next line with the first point already caught
         _Points[0] = SketchEditorTool.Sketch.Points[continueWithPoint];
         _MergePointIndices[0] = continueWithPoint;
 

--- a/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchSegmentBezier3Creator.cs
+++ b/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchSegmentBezier3Creator.cs
@@ -50,7 +50,7 @@ public sealed class SketchSegmentBezier3Creator : SketchSegmentCreator
 
     public override bool Continue(int continueWithPoint)
     {
-        // Start the next line with the first point already catched
+        // Start the next line with the first point already caught
         _Points[0] = SketchEditorTool.Sketch.Points[continueWithPoint];
         _MergePointIndices[0] = continueWithPoint;
 

--- a/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchSegmentEllipticalArcCenterCreator.cs
+++ b/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchSegmentEllipticalArcCenterCreator.cs
@@ -48,7 +48,7 @@ public sealed class SketchSegmentEllipticalArcCenterCreator : SketchSegmentCreat
 
     public override bool Continue(int continueWithPoint)
     {
-        // Start the next line with the first point already catched
+        // Start the next line with the first point already caught
         _Points[1] = SketchEditorTool.Sketch.Points[continueWithPoint];
         _MergePointIndices[1] = continueWithPoint;
 

--- a/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchSegmentLineCreator.cs
+++ b/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchSegmentLineCreator.cs
@@ -47,7 +47,7 @@ public sealed class SketchSegmentLineCreator : SketchSegmentCreator
 
     public override bool Continue(int continueWithPoint)
     {
-        // Start the next line with the first point already catched
+        // Start the next line with the first point already caught
         _Points[0] = SketchEditorTool.Sketch.Points[continueWithPoint];
         _Points[1] = _Points[0];
         _MergePointIndices[0] = continueWithPoint;

--- a/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchTool.cs
+++ b/Source/Macad.Interaction/Editors/Shapes/Sketch/SketchTool.cs
@@ -94,7 +94,7 @@ public abstract class SketchTool : WorkspaceControl
     {
         if (_Actions != null)
         {
-            // Copy reference to disable chaning the enumeration
+            // Copy reference to disable changing the enumeration
             var actions = _Actions;
             _Actions = null;
             foreach (var action in actions)

--- a/Source/Macad.Interaction/Framework/Editor.cs
+++ b/Source/Macad.Interaction/Framework/Editor.cs
@@ -185,7 +185,7 @@ public abstract class Editor : WorkspaceControl
     {
         if (_Actions != null)
         {
-            // Copy reference to disable chaning the enumeration
+            // Copy reference to disable changing the enumeration
             var actions = _Actions;
             _Actions = null;
             foreach (var action in actions)

--- a/Source/Macad.Interaction/Framework/Tool.cs
+++ b/Source/Macad.Interaction/Framework/Tool.cs
@@ -175,7 +175,7 @@ public abstract class Tool : WorkspaceControl
     {
         if (_Actions is { Count: > 0 })
         {
-            // Copy reference to disable chaning the enumeration
+            // Copy reference to disable changing the enumeration
             var actions = _Actions;
             _Actions = null;
             foreach (var toolAction in actions)
@@ -238,7 +238,7 @@ public abstract class Tool : WorkspaceControl
     {
         if (_OverriddenVisualShapes != null)
         {
-            // Copy reference to disable chaning the enumeration
+            // Copy reference to disable changing the enumeration
             var entities = _OverriddenVisualShapes;
             _OverriddenVisualShapes = null;
             foreach (var entity in entities)

--- a/Source/Macad.Interaction/Workspace/WorkspaceController.cs
+++ b/Source/Macad.Interaction/Workspace/WorkspaceController.cs
@@ -283,7 +283,7 @@ public sealed class WorkspaceController : BaseObject, IContextMenuItemProvider, 
 
         _UpdateParameter();
 
-        // Higlight Selected
+        // Highlight Selected
         var selectionDrawer = new Prs3d_Drawer();
         selectionDrawer.SetupOwnDefaults();
         selectionDrawer.SetColor(Colors.Selection.ToQuantityColor());
@@ -297,7 +297,7 @@ public sealed class WorkspaceController : BaseObject, IContextMenuItemProvider, 
         aisContext.SetHighlightStyle(Prs3d_TypeOfHighlight.LocalSelected, selectionDrawer);
         aisContext.SetHighlightStyle(Prs3d_TypeOfHighlight.SubIntensity, selectionDrawer);
 
-        // Higlight Dynamic
+        // Highlight Dynamic
         var hilightDrawer = new Prs3d_Drawer();
         hilightDrawer.SetupOwnDefaults();
         hilightDrawer.SetColor(Colors.Highlight.ToQuantityColor());
@@ -308,7 +308,7 @@ public sealed class WorkspaceController : BaseObject, IContextMenuItemProvider, 
         hilightDrawer.SetDeviationCoefficient(aisContext.DeviationCoefficient());
         aisContext.SetHighlightStyle(Prs3d_TypeOfHighlight.Dynamic, hilightDrawer);
 
-        // Higlight Local
+        // Highlight Local
         var hilightLocalDrawer = new Prs3d_Drawer();
         hilightLocalDrawer.SetupOwnDefaults();
         hilightLocalDrawer.SetColor(Colors.Highlight.ToQuantityColor());

--- a/Source/Macad.Occt/Generated/StdSelect.h
+++ b/Source/Macad.Occt/Generated/StdSelect.h
@@ -289,7 +289,7 @@ public:
     /// </summary>
     void SetHilightMode(int theMode);
     /// <summary>
-    /// Resets the higlight mode for this framework.
+    /// Resets the highlight mode for this framework.
     /// This defines the type of display used to highlight the
     /// owner of the shape when it is detected by the selector.
     /// The default type of display is wireframe, defined by the index 0.

--- a/Source/Macad.Presentation/Controls/TreeView/SelectionMultiple.cs
+++ b/Source/Macad.Presentation/Controls/TreeView/SelectionMultiple.cs
@@ -226,7 +226,7 @@ internal class SelectionMultiple : InputSubscriberBase
         if (item.IsEditing) return;
 
         // Do not select on MouseDown if part of the selection list
-        // To enable drag'n'drop, this selction is done in MouseUp
+        // To enable drag'n'drop, this selection is done in MouseUp
         if (treeViewEx.SelectedItems.Count > 1 && item.IsSelected)
         {
             _ItemForDeferredSelection = item;

--- a/Tests/Test.Interaction/Infrastructure/ViewportTests.cs
+++ b/Tests/Test.Interaction/Infrastructure/ViewportTests.cs
@@ -50,7 +50,7 @@ public class ViewportTests
             // ViewCube is visible
             AssertHelper.IsSameViewport(Path.Combine(_BasePath, "ViewCubeVisible"));
 
-            // Higlight
+            // Highlight
             ctx.MoveTo(360, 120);
             AssertHelper.IsSameViewport(Path.Combine(_BasePath, "ViewCubeHighlight"));
 


### PR DESCRIPTION
Found via: `codespell -S "*.dxf,*.pdf,./Source/Macad.Occt/Generated" -L aline,alocation,anumber,currenty,dirver,doubleclick,enew,filetests,hilight,inout,ist,localy,mis,parm,parms,serie,ther,thes,thet,thev,thex,thirdparty,unhilight,uper`

Note: there are other source typos that haven't been submit yet. Is it possible for someone review and greenlight any of them ? 
'ASTERIKS'
'succsess'
'Auxilliary'
Tranformation
occurance